### PR TITLE
Create invitation template and use hp colors

### DIFF
--- a/templates/invitation.html
+++ b/templates/invitation.html
@@ -438,7 +438,7 @@
 																			padding: 0;
 																			text-align: center;
                                                                         ">
-                                                                Da click en el siguiente botón crear tu cuenta
+                                                                Da click en el siguiente botón para crear tu cuenta
                                                                 </p>
 																<center data-parsed=""
 																	style="min-width: 532px; width: 100%; margin-top:16px;">

--- a/templates/invitation.html
+++ b/templates/invitation.html
@@ -422,7 +422,7 @@
 																			padding: 0;
 																			text-align: center;
                                                                         ">
-                                                                    Has recibido una invitación para formar parte de HP CO-OP.
+                                                                    Has recibido una invitación para formar parte del Programa HP COOP.
 																	
                                                                 </p>
                                                                 <p class="text-center" style="
@@ -531,7 +531,7 @@
 																			padding: 0;
 																			text-align: center;
 																		">
-																	o copia y pega el siguiente link en tu navegador
+																	o copia y pega el siguiente enlace en tu navegador
 																</p>
 																<p class="text-center uno" style="
 																			margin: 0;

--- a/templates/invitation.html
+++ b/templates/invitation.html
@@ -1,0 +1,684 @@
+<!DOCTYPE html>
+<html lang="es" style="background: #f2f2f2 !important;">
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Invitacion</title>
+	<style>
+		@media only screen {
+			html {
+				min-height: 100%;
+				background: #f2f2f2;
+			}
+		}
+
+		@media only screen and (max-width: 596px) {
+			.small-float-center {
+				margin: 0 auto !important;
+				float: none !important;
+				text-align: center !important;
+			}
+		}
+
+		@media only screen and (max-width: 596px) {
+			table.body img {
+				width: auto;
+				height: auto;
+			}
+
+			table.body center {
+				min-width: 0 !important;
+			}
+
+			table.body .container {
+				width: 95% !important;
+			}
+
+			table.body .columns {
+				height: auto !important;
+				-moz-box-sizing: border-box;
+				-webkit-box-sizing: border-box;
+				box-sizing: border-box;
+				padding-left: 16px !important;
+				padding-right: 16px !important;
+			}
+
+			table.body .columns .columns {
+				padding-left: 0 !important;
+				padding-right: 0 !important;
+			}
+
+			table.body .collapse .columns {
+				padding-left: 0 !important;
+				padding-right: 0 !important;
+			}
+
+			th.small-6 {
+				display: inline-block !important;
+				width: 50% !important;
+			}
+
+			th.small-12 {
+				display: inline-block !important;
+				width: 100% !important;
+			}
+
+			.columns th.small-12 {
+				display: block !important;
+				width: 100% !important;
+			}
+
+			table.menu {
+				width: 100% !important;
+			}
+
+			table.menu td,
+			table.menu th {
+				width: auto !important;
+				display: inline-block !important;
+			}
+
+			table.menu.vertical td,
+			table.menu.vertical th {
+				display: block !important;
+			}
+
+			table.menu[align='center'] {
+				width: auto !important;
+			}
+		}
+
+		body {
+			-moz-box-sizing: border-box;
+			-ms-text-size-adjust: 100%;
+			-webkit-box-sizing: border-box;
+			-webkit-text-size-adjust: 100%;
+			margin: 0;
+			background: #f2f2f2 !important;
+			box-sizing: border-box;
+			color: #0a0a0a;
+			font-family: Arial, Helvetica, sans-serif;
+			font-size: 12px;
+			font-weight: 400;
+			line-height: 1.3;
+			margin: 0;
+			min-width: 100%;
+			padding: 0;
+			text-align: left;
+			width: 100% !important;
+		}
+	</style>
+</head>
+
+<body>
+	<span class="preheader"
+		style="color: #f2f2f2; display: none !important; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
+	<table class="body" style="
+				margin: 0;
+				background: #f2f2f2 !important;
+				border-collapse: collapse;
+				border-spacing: 0;
+				color: #0a0a0a;
+				font-family: Arial, Helvetica, sans-serif;
+				font-size: 12px;
+				font-weight: 400;
+				height: 100%;
+				line-height: 1.3;
+				margin: 0;
+				padding: 0;
+				text-align: left;
+				vertical-align: top;
+				width: 100%;
+			">
+		<tr style="padding: 0; text-align: left; vertical-align: top;">
+			<td class="center" align="center" valign="top" style="
+						-moz-hyphens: auto;
+						-webkit-hyphens: auto;
+						margin: 0;
+						border-collapse: collapse !important;
+						color: #0a0a0a;
+						font-family: Arial, Helvetica, sans-serif;
+						font-size: 12px;
+						font-weight: 400;
+						hyphens: auto;
+						line-height: 1.3;
+						margin: 0;
+						padding: 0;
+						text-align: left;
+						vertical-align: top;
+						word-wrap: break-word;
+					">
+				<center data-parsed="" style="min-width: 580px; width: 100%;">
+					<table align="center" class="container header float-center"
+						style="margin: 0 auto; background: #f2f2f2; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
+						<tbody>
+							<tr style="padding: 0; text-align: left; vertical-align: top;">
+								<td style="
+											-moz-hyphens: auto;
+											-webkit-hyphens: auto;
+											margin: 0;
+											border-collapse: collapse !important;
+											color: #0a0a0a;
+											font-family: Arial, Helvetica, sans-serif;
+											font-size: 12px;
+											font-weight: 400;
+											hyphens: auto;
+											line-height: 1.3;
+											margin: 0;
+											padding: 0;
+											text-align: left;
+											vertical-align: top;
+											word-wrap: break-word;
+										">
+									<table class="spacer"
+										style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<td height="16px" style="
+															-moz-hyphens: auto;
+															-webkit-hyphens: auto;
+															margin: 0;
+															border-collapse: collapse !important;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															hyphens: auto;
+															line-height: 16px;
+															margin: 0;
+															mso-line-height-rule: exactly;
+															padding: 0;
+															text-align: left;
+															vertical-align: top;
+															word-wrap: break-word;
+														">
+													&#xA0;
+												</td>
+											</tr>
+										</tbody>
+									</table>
+									<table class="row"
+										style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<th class="small-12 large-6 columns first last" style="
+															margin: 0 auto;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															line-height: 1.3;
+															margin: 0 auto;
+															padding: 0;
+															padding-bottom: 0;
+															padding-left: 16px;
+															padding-right: 16px;
+															text-align: left;
+															width: 274px;
+														">
+													<table
+														style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+														<tr style="padding: 0; text-align: left; vertical-align: top;">
+															<th style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0;
+																		text-align: left;
+																	">
+																<center data-parsed=""
+																	style="min-width: 242px; width: 100%;">
+																	<img src="./assets/logo.svg" alt="" align="center"
+																		class="float-center" style="
+																				-ms-interpolation-mode: bicubic;
+																				margin: 0 auto;
+																				clear: both;
+																				display: block;
+																				float: none;
+																				margin: 0 auto;
+																				max-width: 100%;
+																				outline: 0;
+																				text-align: center;
+																				text-decoration: none;
+																				width: 242px;
+																			" />
+																</center>
+															</th>
+														</tr>
+													</table>
+												</th>
+											</tr>
+										</tbody>
+									</table>
+									<table class="spacer"
+										style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<td height="16px" style="
+															-moz-hyphens: auto;
+															-webkit-hyphens: auto;
+															margin: 0;
+															border-collapse: collapse !important;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															hyphens: auto;
+															line-height: 16px;
+															margin: 0;
+															mso-line-height-rule: exactly;
+															padding: 0;
+															text-align: left;
+															vertical-align: top;
+															word-wrap: break-word;
+														">
+													&#xA0;
+												</td>
+											</tr>
+										</tbody>
+									</table>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+					<table align="center" class="container float-center"
+						style="margin: 0 auto; background: #ffffff; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
+						<tbody>
+							<tr style="padding: 0; text-align: left; vertical-align: top;">
+								<td style="
+											-moz-hyphens: auto;
+											-webkit-hyphens: auto;
+											margin: 0;
+											border-collapse: collapse !important;
+											color: #0a0a0a;
+											font-family: Arial, Helvetica, sans-serif;
+											font-size: 12px;
+											font-weight: 400;
+											hyphens: auto;
+											line-height: 1.3;
+											margin: 0;
+											padding: 0;
+											text-align: left;
+											vertical-align: top;
+											word-wrap: break-word;
+										">
+									<table class="row"
+										style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<th class="small-12 large-12 columns first last" style="
+															margin: 0 auto;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															line-height: 1.3;
+															margin: 0 auto;
+															padding: 0;
+															padding-bottom: 16px;
+															padding-left: 16px;
+															padding-right: 16px;
+															text-align: left;
+															width: 564px;
+														">
+													<table
+														style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+														<tr style="padding: 0; text-align: left; vertical-align: top;">
+															<th style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0;
+																		text-align: left;
+																	">
+																<h3 class="text-center" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #000000;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 30px;
+																			font-weight: normal;
+																			line-height: 110%;
+																			margin: 1.14rem 0 0.912rem 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+																			word-wrap: normal;
+																		">
+																	Tienes una invitación
+																</h3>
+															</th>
+															<th class="expander" style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0 !important;
+																		text-align: left;
+																		visibility: hidden;
+																		width: 0;
+																	"></th>
+														</tr>
+													</table>
+												</th>
+											</tr>
+										</tbody>
+									</table>
+									<table class="row"
+										style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<th class="small-12 large-12 columns first last" style="
+															margin: 0 auto;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															line-height: 1.3;
+															margin: 0 auto;
+															padding: 0;
+															padding-bottom: 16px;
+															padding-left: 16px;
+															padding-right: 16px;
+															text-align: left;
+															width: 564px;
+														">
+													<table
+														style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+														<tr style="padding: 0; text-align: left; vertical-align: top;">
+															<th style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0;
+																		text-align: left;
+																	">
+																<p class="text-center" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #0a0a0a;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 12px;
+																			font-weight: 400;
+																			line-height: 1.3;
+																			margin: 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+                                                                        ">
+                                                                    Has recibido una invitación para formar parte de HP CO-OP.
+																	
+                                                                </p>
+                                                                <p class="text-center" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #0a0a0a;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 12px;
+																			font-weight: 400;
+																			line-height: 1.3;
+																			margin: 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+                                                                        ">
+                                                                Da click en el siguiente botón crear tu cuenta
+                                                                </p>
+																<center data-parsed=""
+																	style="min-width: 532px; width: 100%; margin-top:16px;">
+																	<table class="button rounded float-center" style="
+																				margin: 0 0 16px 0;
+																				border-collapse: collapse;
+																				border-spacing: 0;
+																				float: none;
+																				margin: 0 0 16px 0;
+																				padding: 0;
+																				text-align: center;
+																				vertical-align: top;
+																				width: auto;
+																			">
+																		<tr
+																			style="padding: 0; text-align: left; vertical-align: top;">
+																			<td style="
+																						-moz-hyphens: auto;
+																						-webkit-hyphens: auto;
+																						margin: 0;
+																						border-collapse: collapse !important;
+																						color: #0a0a0a;
+																						font-family: Arial, Helvetica, sans-serif;
+																						font-size: 12px;
+																						font-weight: 400;
+																						hyphens: auto;
+																						line-height: 1.3;
+																						margin: 0;
+																						padding: 0;
+																						text-align: left;
+																						vertical-align: top;
+																						word-wrap: break-word;
+																					">
+																				<table
+																					style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+																					<tr
+																						style="padding: 0; text-align: left; vertical-align: top;">
+																						<td style="
+																									-moz-hyphens: auto;
+																									-webkit-hyphens: auto;
+																									margin: 0;
+																									background: #0096d6;
+																									border: none;
+																									border-collapse: collapse !important;
+																									color: #ffffff;
+																									font-family: Arial, Helvetica, sans-serif;
+																									font-size: 12px;
+																									font-weight: 400;
+																									hyphens: auto;
+																									line-height: 1.3;
+																									margin: 0;
+																									padding: 0;
+																									text-align: left;
+																									vertical-align: top;
+																									word-wrap: break-word;
+																								">
+																							<a href="{{.Link}}" style="
+																										margin: 0;
+																										border: 0 solid #0096d6;
+																										border-radius: 3px;
+																										color: #ffffff;
+																										display: inline-block;
+																										font-family: Arial, Helvetica, sans-serif;
+																										font-size: 16px;
+																										font-weight: normal;
+																										line-height: 40px;
+																										margin: 0;
+																										padding: 0 32px;
+																										text-align: left;
+																										text-decoration: none;
+                                                                                                        text-transform: uppercase;
+																									">Aceptar invitación</a>
+																						</td>
+																					</tr>
+																				</table>
+																			</td>
+																		</tr>
+																	</table>
+																</center>
+																<p class="text-center" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #0a0a0a;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 12px;
+																			font-weight: 400;
+																			line-height: 1.3;
+																			margin: 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+																		">
+																	o copia y pega el siguiente link en tu navegador
+																</p>
+																<p class="text-center uno" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #0096d6;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 12px;
+																			font-weight: 400;
+																			line-height: 1.5;
+																			margin: 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+																		">
+																	{{.Link}}
+																</p>
+															</th>
+															<th class="expander" style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0 !important;
+																		text-align: left;
+																		visibility: hidden;
+																		width: 0;
+																	"></th>
+														</tr>
+													</table>
+												</th>
+											</tr>
+										</tbody>
+									</table>
+									<table class="row collapsed footer"
+										style="border-collapse: collapse; border-spacing: 0; display: table; padding: 0; position: relative; text-align: left; vertical-align: top; width: 100%;">
+										<tbody>
+											<tr style="padding: 0; text-align: left; vertical-align: top;">
+												<th class="small-12 large-12 columns first last" style="
+															margin: 0 auto;
+															color: #0a0a0a;
+															font-family: Arial, Helvetica, sans-serif;
+															font-size: 12px;
+															font-weight: 400;
+															line-height: 1.3;
+															margin: 0 auto;
+															padding: 0;
+															padding-bottom: 16px;
+															padding-left: 16px;
+															padding-right: 16px;
+															text-align: left;
+															width: 564px;
+														">
+													<table
+														style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+														<tr style="padding: 0; text-align: left; vertical-align: top;">
+															<th style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0;
+																		text-align: left;
+																	">
+																<p class="text-center" style="
+																			margin: 0;
+																			margin-bottom: 10px;
+																			color: #0a0a0a;
+																			font-family: Arial, Helvetica, sans-serif;
+																			font-size: 12px;
+																			font-weight: 400;
+																			line-height: 1.3;
+																			margin: 0;
+																			margin-bottom: 10px;
+																			padding: 0;
+																			text-align: center;
+																		">
+																	¡Gracias!
+																</p>
+																<table class="spacer"
+																	style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
+																	<tbody>
+																		<tr
+																			style="padding: 0; text-align: left; vertical-align: top;">
+																			<td height="8px" style="
+																						-moz-hyphens: auto;
+																						-webkit-hyphens: auto;
+																						margin: 0;
+																						border-collapse: collapse !important;
+																						color: #0a0a0a;
+																						font-family: Arial, Helvetica, sans-serif;
+																						font-size: 8px;
+																						font-weight: 400;
+																						hyphens: auto;
+																						line-height: 8px;
+																						margin: 0;
+																						mso-line-height-rule: exactly;
+																						padding: 0;
+																						text-align: left;
+																						vertical-align: top;
+																						word-wrap: break-word;
+																					">
+																				&#xA0;
+																			</td>
+																		</tr>
+																	</tbody>
+																</table>
+																
+															</th>
+															<th class="expander" style="
+																		margin: 0;
+																		color: #0a0a0a;
+																		font-family: Arial, Helvetica, sans-serif;
+																		font-size: 12px;
+																		font-weight: 400;
+																		line-height: 1.3;
+																		margin: 0;
+																		padding: 0 !important;
+																		text-align: left;
+																		visibility: hidden;
+																		width: 0;
+																	"></th>
+														</tr>
+													</table>
+												</th>
+											</tr>
+										</tbody>
+									</table>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</center>
+			</td>
+		</tr>
+	</table>
+	<!-- prevent Gmail on iOS font size manipulation -->
+	<div style="display: none; white-space: nowrap; font: 15px courier; line-height: 0;">
+		&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+		&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+		&nbsp; &nbsp; &nbsp;
+	</div>
+</body>
+
+</html>

--- a/templates/password_recovery.html
+++ b/templates/password_recovery.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
-<html lang="es" style="background: #f3f3f3 !important;">
+<html lang="es" style="background: #f2f2f2 !important;">
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Forgot your password?</title>
+  <title>¿Olvidaste tu contraseña?</title>
   <style>
     @media only screen {
       html {
         min-height: 100%;
-        background: #f3f3f3;
+        background: #f2f2f2;
       }
     }
 
@@ -97,10 +97,10 @@
       -webkit-box-sizing: border-box;
       -webkit-text-size-adjust: 100%;
       margin: 0;
-      background: #f3f3f3 !important;
+      background: #f2f2f2 !important;
       box-sizing: border-box;
-      color: #0a0a0a;
-      font-family: 'Source Sans Pro', sans-serif;
+      color: #000000;
+      font-family: Arial, Helvetica, sans-serif;
       font-size: 16px;
       font-weight: 400;
       line-height: 1.3;
@@ -111,14 +111,14 @@
       width: 100% !important;
     ">
   <span class="preheader"
-    style="color: #f3f3f3; display: none !important; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
+    style="color: #f2f2f2; display: none !important; font-size: 1px; line-height: 1px; max-height: 0; max-width: 0; mso-hide: all !important; opacity: 0; overflow: hidden; visibility: hidden;"></span>
   <table class="body" style="
         margin: 0;
-        background: #f3f3f3 !important;
+        background: #f2f2f2 !important;
         border-collapse: collapse;
         border-spacing: 0;
-        color: #0a0a0a;
-        font-family: 'Source Sans Pro', sans-serif;
+        color: #000000;
+        font-family: Arial, Helvetica, sans-serif;
         font-size: 16px;
         font-weight: 400;
         height: 100%;
@@ -135,8 +135,8 @@
             -webkit-hyphens: auto;
             margin: 0;
             border-collapse: collapse !important;
-            color: #0a0a0a;
-            font-family: 'Source Sans Pro', sans-serif;
+            color: #000000;
+            font-family: Arial, Helvetica, sans-serif;
             font-size: 16px;
             font-weight: 400;
             hyphens: auto;
@@ -149,7 +149,7 @@
           ">
         <center data-parsed="" style="min-width: 580px; width: 100%;">
           <table align="center" class="container header float-center"
-            style="margin: 0 auto; background: #f3f3f3; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
+            style="margin: 0 auto; background: #f2f2f2; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
             <tbody>
               <tr style="padding: 0; text-align: left; vertical-align: top;">
                 <td style="
@@ -157,8 +157,8 @@
                       -webkit-hyphens: auto;
                       margin: 0;
                       border-collapse: collapse !important;
-                      color: #0a0a0a;
-                      font-family: 'Source Sans Pro', sans-serif;
+                      color: #000000;
+                      font-family: Arial, Helvetica, sans-serif;
                       font-size: 16px;
                       font-weight: 400;
                       hyphens: auto;
@@ -178,8 +178,8 @@
                               -webkit-hyphens: auto;
                               margin: 0;
                               border-collapse: collapse !important;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               hyphens: auto;
@@ -202,8 +202,8 @@
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="small-12 large-6 columns first last" style="
                               margin: 0 auto;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               line-height: 1.3;
@@ -220,8 +220,8 @@
                             <tr style="padding: 0; text-align: left; vertical-align: top;">
                               <th style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -229,8 +229,8 @@
                                     padding: 0;
                                     text-align: left;
                                   ">
-                                <center data-parsed="" style="min-width: 242px; width: 100%;">
-                                  <img src="./assets/logo.svg" sv alt="" align="center" class="float-center" style="
+                                <center data-parsed="" style="min-width: 48px; width: 100%;">
+                                  <img src="./assets/Logo_HP_PNG.png" sv alt="" align="center" class="float-center" style="
                                         -ms-interpolation-mode: bicubic;
                                         margin: 0 auto;
                                         clear: both;
@@ -241,7 +241,7 @@
                                         outline: 0;
                                         text-align: center;
                                         text-decoration: none;
-                                        width: 242px;
+                                        width: 48px;
                                       " />
                                 </center>
                               </th>
@@ -260,8 +260,8 @@
                               -webkit-hyphens: auto;
                               margin: 0;
                               border-collapse: collapse !important;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               hyphens: auto;
@@ -283,7 +283,7 @@
             </tbody>
           </table>
           <table align="center" class="container float-center"
-            style="margin: 0 auto; background: #fefefe; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
+            style="margin: 0 auto; background: #ffffff; border-collapse: collapse; border-spacing: 0; float: none; margin: 0 auto; padding: 0; text-align: center; vertical-align: top; width: 580px;">
             <tbody>
               <tr style="padding: 0; text-align: left; vertical-align: top;">
                 <td style="
@@ -291,8 +291,8 @@
                       -webkit-hyphens: auto;
                       margin: 0;
                       border-collapse: collapse !important;
-                      color: #0a0a0a;
-                      font-family: 'Source Sans Pro', sans-serif;
+                      color: #000000;
+                      font-family: Arial, Helvetica, sans-serif;
                       font-size: 16px;
                       font-weight: 400;
                       hyphens: auto;
@@ -309,8 +309,8 @@
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="small-12 large-12 columns first last" style="
                               margin: 0 auto;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               line-height: 1.3;
@@ -327,8 +327,8 @@
                             <tr style="padding: 0; text-align: left; vertical-align: top;">
                               <th style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -339,10 +339,10 @@
                                 <h2 class="text-center" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #25408d;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 2.28rem;
-                                      font-weight: 900;
+                                      color: #000000;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 30px;
+                                      font-weight: normal;
                                       line-height: 110%;
                                       margin: 1.14rem 0 0.912rem 0;
                                       margin-bottom: 10px;
@@ -350,13 +350,13 @@
                                       text-align: center;
                                       word-wrap: normal;
                                     ">
-                                  Forgot your password?
+                                  ¿Olvidaste tu contraseña?
                                 </h2>
                               </th>
                               <th class="expander" style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -378,8 +378,8 @@
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="small-12 large-12 columns first last" style="
                               margin: 0 auto;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               line-height: 1.3;
@@ -396,8 +396,8 @@
                             <tr style="padding: 0; text-align: left; vertical-align: top;">
                               <th style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -408,9 +408,9 @@
                                 <p class="text-center" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #0a0a0a;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
+                                      color: #000000;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 12px;
                                       font-weight: 400;
                                       line-height: 1.3;
                                       margin: 0;
@@ -418,14 +418,14 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  Someone requested that the password for your CO-OP account be reset.
+                                  Estás recibiendo este correo porque solicitaste la recuperación de contraseña para tu cuenta.
                                 </p>
                                 <p class="text-center" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #0a0a0a;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
+                                      color: #000000;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 12px;
                                       font-weight: 400;
                                       line-height: 1.3;
                                       margin: 0;
@@ -433,9 +433,9 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  Click the button to reset your password
+                                  Presiona el botón para restablecer tu contraseña
                                 </p>
-                                <center data-parsed="" style="min-width: 532px; width: 100%;">
+                                <center data-parsed="" style="min-width: 532px; width: 100%; margin-top: 16px;">
                                   <table class="button rounded float-center" style="
                                         margin: 0 0 16px 0;
                                         border-collapse: collapse;
@@ -453,8 +453,8 @@
                                             -webkit-hyphens: auto;
                                             margin: 0;
                                             border-collapse: collapse !important;
-                                            color: #0a0a0a;
-                                            font-family: 'Source Sans Pro', sans-serif;
+                                            color: #000000;
+                                            font-family: Arial, Helvetica, sans-serif;
                                             font-size: 16px;
                                             font-weight: 400;
                                             hyphens: auto;
@@ -472,12 +472,11 @@
                                                   -moz-hyphens: auto;
                                                   -webkit-hyphens: auto;
                                                   margin: 0;
-                                                  background: #002cb2;
+                                                  background: #0096d6;
                                                   border: none;
                                                   border-collapse: collapse !important;
-                                                  border-radius: 500px;
-                                                  color: #fefefe;
-                                                  font-family: 'Source Sans Pro', sans-serif;
+                                                  color: #ffffff;
+                                                  font-family: Arial, Helvetica, sans-serif;
                                                   font-size: 16px;
                                                   font-weight: 400;
                                                   hyphens: auto;
@@ -490,19 +489,20 @@
                                                 ">
                                               <a href="{{.link}}" style="
                                                     margin: 0;
-                                                    border: 0 solid #002cb2;
+                                                    border: 0 solid #0096d6;
                                                     border-radius: 3px;
-                                                    color: #fefefe;
+                                                    color: #ffffff;
                                                     display: inline-block;
-                                                    font-family: 'Source Sans Pro', sans-serif;
+                                                    font-family: Arial, Helvetica, sans-serif;
                                                     font-size: 16px;
-                                                    font-weight: 700;
-                                                    line-height: 1.3;
+                                                    font-weight: normal;
+                                                    line-height: 40px;
                                                     margin: 0;
-                                                    padding: 8px 16px 8px 16px;
+                                                    padding: 0px 32px;
                                                     text-align: left;
                                                     text-decoration: none;
-                                                  ">Reset password</a>
+                                                    text-transform: uppercase;
+                                                  ">Restablecer contraseña</a>
                                             </td>
                                           </tr>
                                         </table>
@@ -513,9 +513,9 @@
                                 <p class="text-center" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #0a0a0a;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
+                                      color: #000000;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 12px;
                                       font-weight: 400;
                                       line-height: 1.3;
                                       margin: 0;
@@ -523,16 +523,16 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  Or copy and paste the following link in your browser
+                                  o copia y pega el siguiente link en tu navegador
                                 </p>
                                 <p class="text-center uno" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #002cb2;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
+                                      color: #0096d6;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 12px;
                                       font-weight: 400;
-                                      line-height: 1.3;
+                                      line-height: 1.5;
                                       margin: 0;
                                       margin-bottom: 10px;
                                       padding: 0;
@@ -543,8 +543,8 @@
                               </th>
                               <th class="expander" style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -566,8 +566,8 @@
                       <tr style="padding: 0; text-align: left; vertical-align: top;">
                         <th class="small-12 large-12 columns first last" style="
                               margin: 0 auto;
-                              color: #0a0a0a;
-                              font-family: 'Source Sans Pro', sans-serif;
+                              color: #000000;
+                              font-family: Arial, Helvetica, sans-serif;
                               font-size: 16px;
                               font-weight: 400;
                               line-height: 1.3;
@@ -584,8 +584,8 @@
                             <tr style="padding: 0; text-align: left; vertical-align: top;">
                               <th style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;
@@ -593,39 +593,12 @@
                                     padding: 0;
                                     text-align: left;
                                   ">
-                                <table class="spacer"
-                                  style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
-                                  <tbody>
-                                    <tr style="padding: 0; text-align: left; vertical-align: top;">
-                                      <td height="16px" style="
-                                            -moz-hyphens: auto;
-                                            -webkit-hyphens: auto;
-                                            margin: 0;
-                                            border-collapse: collapse !important;
-                                            color: #0a0a0a;
-                                            font-family: 'Source Sans Pro', sans-serif;
-                                            font-size: 16px;
-                                            font-weight: 400;
-                                            hyphens: auto;
-                                            line-height: 16px;
-                                            margin: 0;
-                                            mso-line-height-rule: exactly;
-                                            padding: 0;
-                                            text-align: left;
-                                            vertical-align: top;
-                                            word-wrap: break-word;
-                                          ">
-                                        &#xA0;
-                                      </td>
-                                    </tr>
-                                  </tbody>
-                                </table>
                                 <p class="text-center dos" style="
                                       margin: 0;
                                       margin-bottom: 10px;
-                                      color: #25408d;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
+                                      color: #000000;
+                                      font-family: Arial, Helvetica, sans-serif;
+                                      font-size: 12px;
                                       font-weight: 400;
                                       line-height: 1.3;
                                       margin: 0;
@@ -633,7 +606,7 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  <strong>Thank you<strong></strong></strong>
+                                  ¡Gracias!
                                 </p>
                                 <table class="spacer"
                                   style="border-collapse: collapse; border-spacing: 0; padding: 0; text-align: left; vertical-align: top; width: 100%;">
@@ -644,8 +617,8 @@
                                             -webkit-hyphens: auto;
                                             margin: 0;
                                             border-collapse: collapse !important;
-                                            color: #0a0a0a;
-                                            font-family: 'Source Sans Pro', sans-serif;
+                                            color: #000000;
+                                            font-family: Arial, Helvetica, sans-serif;
                                             font-size: 8px;
                                             font-weight: 400;
                                             hyphens: auto;
@@ -662,25 +635,11 @@
                                     </tr>
                                   </tbody>
                                 </table>
-                                <p class="text-center" style="
-                                      margin: 0;
-                                      margin-bottom: 10px;
-                                      color: #0a0a0a;
-                                      font-family: 'Source Sans Pro', sans-serif;
-                                      font-size: 16px;
-                                      font-weight: 400;
-                                      line-height: 1.3;
-                                      margin: 0;
-                                      margin-bottom: 10px;
-                                      padding: 0;
-                                      text-align: center;
-                                    ">
-                                </p>
                               </th>
                               <th class="expander" style="
                                     margin: 0;
-                                    color: #0a0a0a;
-                                    font-family: 'Source Sans Pro', sans-serif;
+                                    color: #000000;
+                                    font-family: Arial, Helvetica, sans-serif;
                                     font-size: 16px;
                                     font-weight: 400;
                                     line-height: 1.3;

--- a/templates/password_recovery.html
+++ b/templates/password_recovery.html
@@ -523,7 +523,7 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  o copia y pega el siguiente link en tu navegador
+                                  o copia y pega el siguiente enlace en tu navegador
                                 </p>
                                 <p class="text-center uno" style="
                                       margin: 0;


### PR DESCRIPTION
# Problem Description
- We needed a template for user invitations
- We needed to modify the templates styling to follow hp brand manual

# Features
- Add new template for user invitations
- Change template to spanish
- Change template styling (font-size, colors)

# Where this change will be used
- This change will be used when sending password recovery and invitation emails

# More details
- Password recovery template
![image](https://user-images.githubusercontent.com/53949651/113076763-011c9a00-918d-11eb-9b7f-563cf9259977.png)

- Invitation template
![image](https://user-images.githubusercontent.com/53949651/113076742-f19d5100-918c-11eb-86f8-ae6be8698f3f.png)



