### PR TITLE
Change link color

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -6,6 +6,7 @@ type Template string
 
 const (
 	PasswordRecovery = Template("password_recovery.html")
+	UserInvitation   = Template("invitation.html")
 	TestTemplate     = Template("test_template.html")
 )
 

--- a/templates/invitation.html
+++ b/templates/invitation.html
@@ -495,7 +495,7 @@
 																									vertical-align: top;
 																									word-wrap: break-word;
 																								">
-																							<a href="{{.Link}}" style="
+																							<a href="{{.link}}" style="
 																										margin: 0;
 																										border: 0 solid #0096d6;
 																										border-radius: 3px;
@@ -546,7 +546,9 @@
 																			padding: 0;
 																			text-align: center;
 																		">
-																	{{.Link}}
+																	<a href="{{.link}}" style="
+																		color: #0096d6;
+																	">{{.link}}</a>
 																</p>
 															</th>
 															<th class="expander" style="

--- a/templates/password_recovery.html
+++ b/templates/password_recovery.html
@@ -538,7 +538,9 @@
                                       padding: 0;
                                       text-align: center;
                                     ">
-                                  {{.link}}
+                                  <a href="{{.link}}" style="
+                                    color: #0096d6;
+                                  ">{{.link}}</a>
                                 </p>
                               </th>
                               <th class="expander" style="


### PR DESCRIPTION
# Problem Description
- We need a template for user invitation emails

# Features
- Add constant to use invitation template

# Bug Fixes
- Change Link to link in template placeholders so they are all in lowercase
- Change link color to match button color

# Where this change will be used
- This change will be used in password recovery and invitation emails


# More details
![image](https://user-images.githubusercontent.com/53949651/113170068-72972f80-9203-11eb-8aea-e546b250babe.png)

