### PR TITLE
Change copies and remove stale img tag

### DIFF
--- a/templates/invitation.go
+++ b/templates/invitation.go
@@ -233,23 +233,6 @@ const UserInvitation = `<!DOCTYPE html>
 																		padding: 0;
 																		text-align: left;
 																	">
-																<center data-parsed=""
-																	style="min-width: 242px; width: 100%;">
-																	<img src="./assets/logo.svg" alt="" align="center"
-																		class="float-center" style="
-																				-ms-interpolation-mode: bicubic;
-																				margin: 0 auto;
-																				clear: both;
-																				display: block;
-																				float: none;
-																				margin: 0 auto;
-																				max-width: 100%;
-																				outline: 0;
-																				text-align: center;
-																				text-decoration: none;
-																				width: 242px;
-																			" />
-																</center>
 															</th>
 														</tr>
 													</table>
@@ -424,7 +407,7 @@ const UserInvitation = `<!DOCTYPE html>
 																			padding: 0;
 																			text-align: center;
                                                                         ">
-                                                                    Has recibido una invitación para formar parte del Programa HP COOP.
+																	Has recibido una invitacion para formar parte de la Web del Programa HP CO-OP
 																	
                                                                 </p>
                                                                 <p class="text-center" style="

--- a/templates/password_recovery.go
+++ b/templates/password_recovery.go
@@ -231,21 +231,6 @@ const PasswordRecovery = `<!DOCTYPE html>
                                     padding: 0;
                                     text-align: left;
                                   ">
-                                <center data-parsed="" style="min-width: 48px; width: 100%;">
-                                  <img src="./assets/Logo_HP_PNG.png" sv alt="" align="center" class="float-center" style="
-                                        -ms-interpolation-mode: bicubic;
-                                        margin: 0 auto;
-                                        clear: both;
-                                        display: block;
-                                        float: none;
-                                        margin: 0 auto;
-                                        max-width: 100%;
-                                        outline: 0;
-                                        text-align: center;
-                                        text-decoration: none;
-                                        width: 48px;
-                                      " />
-                                </center>
                               </th>
                             </tr>
                           </table>


### PR DESCRIPTION
# Problem Description
- We want to change invitation email copy and remove img tags

# Features
- Modify message in email invitation body

# Bug Fixes
- Remove img tag from invitation and password recovery emails

# Where this change will be used
- This changes will be used when sending invitation and password recovery emails

